### PR TITLE
Bug fixed

### DIFF
--- a/app/src/main/java/com/example/rvanimationtest/UI/MainActivity.java
+++ b/app/src/main/java/com/example/rvanimationtest/UI/MainActivity.java
@@ -34,8 +34,6 @@ public class MainActivity extends AppCompatActivity {
 
         iniViews();
 
-        iniNewsList();
-
         // грузим сохраенный boolean
         isDark = getThemeStatePref();
         if (isDark){
@@ -47,6 +45,8 @@ public class MainActivity extends AppCompatActivity {
             searchInput.setBackgroundResource(R.drawable.search_input_style);
             rootLayout.setBackgroundColor(getResources().getColor(R.color.white));
         }
+
+        iniNewsList();
 
         fabSwitcher.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
Починил баг:

Если сохранялась темная тема в SharedPref, то при загрузке сначала грузился список (по дефолту белый, а нужно темный)

Теперь подтягивается значение сохраненной SharedPref isDark раньше, чем список отображается.